### PR TITLE
add levels (0,1,2 etc) to rows. Fix grid bug  when parentRootValue!=null

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ use yii\db\ActiveRecord;
  */
 class Tree extends ActiveRecord 
 {
-
+    public $level;
     /**
      * @inheritdoc
      */
@@ -99,17 +99,17 @@ use leandrogehlen\treegrid\TreeGrid;
     'dataProvider' => $dataProvider,
     'keyColumnName' => 'id',
     'parentColumnName' => 'parent_id',
+    'levelColumnName' => 'level',
     'parentRootValue' => '0', //first parentId value
     'pluginOptions' => [
         'initialState' => 'collapsed',
     ],
     'columns' => [
         'name',
+        'level',
         'id',
         'parent_id',
         ['class' => 'yii\grid\ActionColumn']
     ]     
 ]); ?>
 ```
-
-

--- a/TreeGrid.php
+++ b/TreeGrid.php
@@ -252,7 +252,7 @@ class TreeGrid extends Widget
         Html::addCssClass($options, "treegrid-$id");
 
         $parentId = ArrayHelper::getValue($model, $this->parentColumnName);
-        if ($parentId) {
+        if ($parentId and $parentId !==$this->parentRootValue) {
             if(ArrayHelper::getValue($this->pluginOptions, 'initialState') == 'collapsed'){
                 Html::addCssStyle($options, 'display: none;');
             }
@@ -412,8 +412,10 @@ class TreeGrid extends Widget
                 if ($children) {
                     $result = array_merge($result, $children);
                 }
+                $level--;
             }
+            
         }
         return $result;
     }
-} 
+}

--- a/TreeGrid.php
+++ b/TreeGrid.php
@@ -135,6 +135,11 @@ class TreeGrid extends Widget
     public $parentColumnName;
 
     /**
+     * @var string name of model property to store levels
+     */
+    public $levelColumnName = null;
+
+    /**
      * @var mixed parent column value of root elements from data
      */
     public $parentRootValue = null;
@@ -394,12 +399,16 @@ class TreeGrid extends Widget
      * @param string $parentId
      * @return array
      */
-    protected function normalizeData(array $data, $parentId = null) {
+    protected function normalizeData(array $data, $parentId = null, $level = 0) {
         $result = [];
         foreach ($data as $element) {
             if (ArrayHelper::getValue($element, $this->parentColumnName) === $parentId) {
+                if($this->levelColumnName){
+                    $element[$this->levelColumnName] = $level;
+                }
+                $level++;
                 $result[] = $element;
-                $children = $this->normalizeData($data, ArrayHelper::getValue($element, $this->keyColumnName));
+                $children = $this->normalizeData($data, ArrayHelper::getValue($element, $this->keyColumnName), $level);
                 if ($children) {
                     $result = array_merge($result, $children);
                 }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0.x-dev"
+            "dev-master": "1.0.2"
         }
     }
 }


### PR DESCRIPTION
in TreeGrid.php at line 255 
`if ($parentId)`  
executes always where $parentId not null. Even for a first level elements of $models. It adds treegrid-parent-\* to HTML and table body dosen't shows al all.
